### PR TITLE
(LoctiteUtils) Changed the storyboard separator.

### DIFF
--- a/Loctite/JMGLoctiteUtils.m
+++ b/Loctite/JMGLoctiteUtils.m
@@ -30,11 +30,15 @@
 
 @implementation JMGLoctiteUtils
 
-static const NSString *kStoryboardSeparator = @"_";
+
+static const NSString *kDefaultStoryboardSeparator = @".";
+static const NSString *kStoryboardSeparatorInfoKey = @"Loctite Separator";
 
 
 + (UIViewController *)viewControllerForPath:(NSString *)identifier{
-    NSArray *info = [identifier componentsSeparatedByString:kStoryboardSeparator];
+    
+    NSString *customSeparator = [[NSBundle mainBundle] objectForInfoDictionaryKey:kStoryboardSeparatorInfoKey];
+    NSArray *info = [identifier componentsSeparatedByString:(customSeparator) ?: kDefaultStoryboardSeparator];
     
     NSString *storyboardFile = info[0];
     NSString *destinationIdentifier = info[1];

--- a/Loctite/JMGLoctiteUtils.m
+++ b/Loctite/JMGLoctiteUtils.m
@@ -30,8 +30,11 @@
 
 @implementation JMGLoctiteUtils
 
-+ (UIViewController *)viewControllerForPath:(NSString *)identifier {
-    NSArray *info = [identifier componentsSeparatedByString:@"."];
+static const NSString *kStoryboardSeparator = @"_";
+
+
++ (UIViewController *)viewControllerForPath:(NSString *)identifier{
+    NSArray *info = [identifier componentsSeparatedByString:kStoryboardSeparator];
     
     NSString *storyboardFile = info[0];
     NSString *destinationIdentifier = info[1];

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ After that, you only need to set segue identifier to `[storyboard_file].[viewcon
 
 ![Storyboard](Screenshots/storyboard.png)
 
+If you need a different separator rather than '.', you can specify it on your project's info.plist, using the key 'Loctite Separator'. This key will override the default one.
+Example: using "Loctite Separator : _" in your info.plist, Loctite would expect your segue identifiers as `[storyboard_file]_[viewcontroller_identifier]`.
+
 Anyway, my recomendation is to inspect __Demo project__ to see examples.
 
 ## Author


### PR DESCRIPTION
Now instead of a dot ('.') it uses a custom identifier set inside Info Project dictionary, with key 'Lactite Separator' as String, in order to prevent compile errors when using these identifiers as constants in code.

Using a library such as sbconstants, when writing identifiers with dots on a constants file was causing compiling errors.

I have added a constant on LoctiteUtils in order to make a bit easier to locate this string separator if anyone needs to change its behaviour.
